### PR TITLE
Fix iTerms preferences

### DIFF
--- a/iterm2/run.sh
+++ b/iterm2/run.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 set -ex
-
 BASEDIR=$(dirname "$(readlink -f "$0")")
-ITERM2_PATH="${HOME}/.iterm2"
-
-mkdir -p "${ITERM2_PATH}"
-
-# Create symlinks
-ln -sfv "${BASEDIR}/com.googlecode.iterm2.plist" "${ITERM2_PATH}"
 
 # Set the iTerm2 preferences directory.
-defaults write com.googlecode.iterm2.plist PrefsCustomFolder -string "${ITERM2_PATH}"
+defaults write com.googlecode.iterm2.plist PrefsCustomFolder -string "${BASEDIR}"
 
 # Enable iTerm2 to use the custom preference directory.
 defaults write com.googlecode.iterm2.plist LoadPrefsFromCustomFolder -bool true


### PR DESCRIPTION
plist files are managed by MacOs and cannot be symlinked. Fix the config by pointing iTerm2 to to plist file within the dotsfiles repository.