### PR TITLE
Use jsonc linting for VSCode's setting file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "overrides": [
+    {
+      "files": ["vscode/settings.json"],
+      "extends": ["plugin:jsonc/recommended-with-jsonc"]
+    }
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "overrides": [
-    {
-      "files": ["vscode/settings.json"],
-      "extends": ["plugin:jsonc/recommended-with-jsonc"]
-    }
-  ]
-}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,4 +18,5 @@ jobs:
         uses: github/super-linter/slim@v5
         env:
           DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: .*vscode/settings\.json
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
VSCode's `settings.json` has JSONC comments but uses a `.json` extension which fails linting with the following error:
```
2026-03-08 07:31:25 [INFO]   
2026-03-08 07:31:25 [INFO]   ----------------------------------------------
2026-03-08 07:31:25 [INFO]   ----------------------------------------------
2026-03-08 07:31:25 [INFO]   Linting [JSON] files...
2026-03-08 07:31:25 [INFO]   ----------------------------------------------
2026-03-08 07:31:25 [INFO]   ----------------------------------------------
2026-03-08 07:31:25 [INFO]   ---------------------------
2026-03-08 07:31:25 [INFO]   File:[/github/workspace/cursor/settings.json]
2026-03-08 07:31:26 [INFO]    - File:[settings.json] was linted with [eslint] successfully
2026-03-08 07:31:26 [INFO]   ---------------------------
2026-03-08 07:31:26 [INFO]   File:[/github/workspace/vscode/settings.json]
2026-03-08 07:31:28 [ERROR]   Found errors in [eslint] linter!
2026-03-08 07:31:28 [ERROR]   Error code: 1. Command output:
```